### PR TITLE
Fix outdated content in workshop-linked docs ahead of training

### DIFF
--- a/MODELS_USE_CASES.md
+++ b/MODELS_USE_CASES.md
@@ -9,39 +9,39 @@ nav_order: 1
 
 When integrating AI agents into your development process, selecting the right foundation model is critical for productivity, quality of the output code, and cost-efficiency. Based on our internal experiment and industry observations, here’s how to evaluate and use the leading models:
 
-## Claude 3.5 / 3.7 (Anthropic)
+## Claude Sonnet 4.6 (Anthropic)
 
-**Strengths:** Best for reasoning-heavy tasks like debugging, architecture decisions, system design, and breaking down complex prompts.
-**Context Window:** ~128K tokens (Claude 3.7), great for multi-file reasoning and complex feature generation.
-**When to avoid:** High-frequency interactive prompting (Claude is slightly slower) or when token costs are a concern.
+**Strengths:** Best for reasoning-heavy tasks like debugging, architecture decisions, system design, and breaking down complex prompts. With Thinking effort set to High, it excels at multi-step planning and structured output.
+**Context Window:** 200K tokens, well-suited for multi-file reasoning and complex feature generation.
+**When to avoid:** High-frequency interactive prompting where speed is the priority, or when token costs are a concern.
 
-### Ideal Use Cases Claude 3.5 / 3.7 (Anthropic)
+### Ideal Use Cases for Claude Sonnet 4.6 (Anthropic)
 
 - Writing comprehensive specs or planning files like `spec.md`, `plan.md` or `todo.md`.
-- Refactoring legacy code with unclear logic but with relatively low amount of code.
+- Refactoring legacy code with unclear logic.
 - Debugging hard-to-identify issues with long history or dependencies.
 
-## GPT-4o (OpenAI)
+## GPT-5.4 / GPT-5.4 mini (OpenAI)
 
-**Strengths:** Excellent for fast code generation, frontend scaffolding, and prototyping. Very fluent and interactive.
-**Context Window:** 128K tokens.
-**When to avoid:** Tasks that require deep logical steps across complex services — less precise in those scenarios compared to Claude.
+**Strengths:** The GPT-5.4 family covers the full spectrum from fast/cheap to flagship reasoning. GPT-5.4 mini is the go-to for speed and cost; GPT-5.4 balances quality and cost; GPT-5.5 is also available for complex reasoning at higher cost.
+**Context Window:** 400K tokens (GPT-5.4 mini), 1M tokens (GPT-5.4, GPT-5.5).
+**When to avoid:** GPT-5.4 mini for tasks requiring deep multi-step reasoning — use GPT-5.4 or GPT-5.5 instead.
 
-### Ideal Use Cases for GPT-4o (OpenAI)
+### Ideal Use Cases for GPT-5.4 / GPT-5.4 mini (OpenAI)
 
-- Quick iteration of UI components.
-- Writing test files, simple APIs, or scaffolding endpoints.
-- Real-time coding during pair-programming sessions.
+- Quick iteration of UI components and scaffolding (GPT-5.4 mini).
+- Writing test files, simple APIs, or scaffolding endpoints (GPT-5.4 mini / GPT-5.4).
+- Architectural reasoning, complex debugging, and coding tasks on par with Claude (GPT-5.4 / GPT-5.5).
 
-## Gemini 2.5 Pro (Google)
+## Gemini 2.5 Pro / Gemini 3.1 Pro (Google)
 
-**Strengths:** Best model for full-repo understanding, DevOps, and infrastructure-as-code. Extremely powerful context window.
+**Strengths:** Best model for full-repo understanding, DevOps, and infrastructure-as-code. Extremely powerful context window. Gemini 2.5 Pro is the current stable release; Gemini 3.1 Pro is available in preview with enhanced agentic and coding capabilities.
 
-**Context Window:** Up to 1M tokens (2M with special setups).
+**Context Window:** Up to 1M tokens (Gemini 2.5 Pro).
 
-**When to avoid:** Prompting conversationally on very small tasks — might be overkill in terms of latency and cost.
+**When to avoid:** Prompting conversationally on very small tasks — might be overkill in terms of latency and cost. Use Gemini 3 Flash (Preview) for lighter, high-volume tasks.
 
-### Ideal Use Cases for Gemini 2.5 Pro (Google)
+### Ideal Use Cases for Gemini 2.5 Pro / Gemini 3.1 Pro (Google)
 
 - Modifying infra using CDK/Terraform.
 - Coordinating changes across microservices or large monorepos.
@@ -49,13 +49,14 @@ When integrating AI agents into your development process, selecting the right fo
 
 ## Comparison table
 
-| **LLM**    | **Best at**                                         | **Avoid when**                          |
-| ---------- | --------------------------------------------------- | --------------------------------------- |
-| Claude 3.7 | System reasoning, specs, debugging                  | You need fast short feedback loops      |
-| GPT 4o     | UI, scaffolding, fast prompting                     | You need deep logical accuracy          |
-| Gemini 2.5 | Infra/codebase-wide operations and larger codebases | You're doing small or interactive tasks |
+| **LLM**           | **Best at**                                         | **Avoid when**                          |
+| ----------------- | --------------------------------------------------- | --------------------------------------- |
+| Claude Sonnet 4.6 | System reasoning, specs, debugging                  | You need fast short feedback loops      |
+| GPT-5.4 mini      | UI, scaffolding, fast/cheap prompting               | You need deep logical accuracy          |
+| GPT-5.4 / GPT-5.5 | Complex reasoning and coding on par with Claude    | Speed and low latency are the priority  |
+| Gemini 2.5 Pro / 3.1 Pro | Infra/codebase-wide operations and larger codebases | You're doing small or interactive tasks |
 
-Each model offers a unique advantage depending on the nature of the task. For day-to-day work, a combination approach using GPT-4o for speed and Claude/Gemini for structure often yields the best outcome.
+Each model offers a unique advantage depending on the nature of the task. For day-to-day work, a combination approach using GPT-5.4 mini for speed and Claude Sonnet 4.6 or Gemini for structure often yields the best outcome.
 
 ## Token Efficiency & Cost Awareness in AI Coding Workflows
 
@@ -84,8 +85,8 @@ This section explains why developers must learn to work efficiently, and why eng
 - **One Task per Prompt:** Instead of asking for a test, refactor, and docs in one go — split into focused steps. Reduces retries and output bloat.
 - **Limit Output Size:** Add constraints: `Return only the code, no explanation.`, `Limit to 20 lines.` Keeps the interaction sharp and reduces unnecessary token consumption, especially in tools where both input and output count toward your quota.
 - **Avoid Recursive Prompt Chains Without Limits:** Prompts like `Refine this 10 times` may sound clever but can generate thousands of tokens. Use: `Improve this once. Stop after 2 iterations.`
-- **Use Shorter Models for Simpler Tasks:** For documentation, variable naming, or test generation, models like GPT-3.5 or Claude 3.5 are cheaper and fast enough.
-  Reserve GPT-4 or Claude 3.7 for architectural reasoning or multi-file refactoring.
+- **Use Lighter Models for Simpler Tasks:** For documentation, variable naming, or test generation, faster and cheaper options like GPT-5.4 mini are often sufficient.
+  Reserve GPT-5.4, GPT-5.5, or Claude Sonnet 4.6 (with Thinking effort High) for architectural reasoning or multi-file refactoring.
 - **Use Memory Banks and Instructions Files:** Store recurring context (architecture rules, naming patterns, stack details) in `.github/copilot-instructions.md`, `.cursor/rules`, or `CLAUDE.md`. This prevents repeating the same setup context in every prompt — a common source of wasted tokens.
 
 | **Prompt Style**          | **Input Tokens** | **Output Tokens** | **Total** | **Result**               |

--- a/MODELS_USE_CASES.md
+++ b/MODELS_USE_CASES.md
@@ -52,7 +52,7 @@ When integrating AI agents into your development process, selecting the right fo
 | **LLM**           | **Best at**                                         | **Avoid when**                          |
 | ----------------- | --------------------------------------------------- | --------------------------------------- |
 | Claude Sonnet 4.6 | System reasoning, specs, debugging                  | You need fast short feedback loops      |
-| GPT-5.4 mini      | UI, scaffolding, fast/cheap prompting               | You need deep logical accuracy          |
+| GPT-5.4 mini      | UI, scaffolding, fast/cheap prompting               | You need deep multi-step reasoning      |
 | GPT-5.4 / GPT-5.5 | Complex reasoning and coding on par with Claude    | Speed and low latency are the priority  |
 | Gemini 2.5 Pro / 3.1 Pro | Infra/codebase-wide operations and larger codebases | You're doing small or interactive tasks |
 

--- a/TRAINING.md
+++ b/TRAINING.md
@@ -6,7 +6,7 @@
 
 [**Slide Deck**](https://docs.google.com/presentation/d/1bdjGgnPWV6Dqhi7Hy7KOZvqM1iz-u7q5M5CSBbxZi5o/edit?slide=id.g1ff7b2f3b96_0_2674&pli=1#slide=id.g1ff7b2f3b96_0_2674)
 
-[**Training Repository**](https://github.com/moacir-rodrigues-petry/agentic-coding-wip)
+[**Training Repository**](https://github.com/ModusCreateOrg/agentic-coding-training)
 
 ---
 
@@ -42,7 +42,7 @@ GitHub Copilot Agent Mode represents the next evolution in AI-assisted developme
 **Required Setup (Complete 24 hours before training):**
 - [ ] **GitHub Copilot Business/Enterprise subscription** with Agent Mode enabled
 - [ ] **Supported IDE installed** (VS Code recommended; Cursor supported; JetBrains supported but Agent Mode features may vary)
-- [ ] **Fork or clone the training repository**: https://github.com/moacir-rodrigues-petry/agentic-coding-wip
+- [ ] **Fork or clone the training repository**: https://github.com/ModusCreateOrg/agentic-coding-training
 - [ ] **Verify Agent Mode is available** in the Copilot Chat panel (Ask / Plan / Agent dropdown)
 - [ ] **Verify Agent Mode functionality** with a simple test prompt
 - [ ] **Join training Slack channel**: #copilot-agent-training

--- a/TRAINING.md
+++ b/TRAINING.md
@@ -16,10 +16,10 @@ GitHub Copilot Agent Mode represents the next evolution in AI-assisted developme
 
 **How Agent Mode differs from other Copilot approaches:**
 
-1. **Copilot Inline** - Provides real-time code completions and suggestions within individual files
-2. **Copilot Chat** - Offers conversational assistance for coding questions and guidance
-3. **Copilot Edits** - Enables multi-file editing based on single prompts
-4. **Copilot Agent Mode** - **NEW**: Autonomous project-level operations with contextual awareness, architectural understanding, and multi-step task execution
+1. **Copilot Inline** - Provides real-time code completions and suggestions within the editor (always-on, beneath all other modes)
+2. **Ask** - Conversational assistance for coding questions, explanations, and guidance
+3. **Plan** - Generates a step-by-step implementation plan for review and approval before any code is written
+4. **Agent** - Autonomous project-level operations with contextual awareness, architectural understanding, and multi-step task execution
 
 **Why Agent Mode matters:**
 - **Project-level intelligence**: Understands entire codebases, not just individual files
@@ -41,9 +41,9 @@ GitHub Copilot Agent Mode represents the next evolution in AI-assisted developme
 
 **Required Setup (Complete 24 hours before training):**
 - [ ] **GitHub Copilot Business/Enterprise subscription** with Agent Mode enabled
-- [ ] **Supported IDE installed** (VS Code, Cursor, or JetBrains with latest Copilot extension)
-- [ ] **Fork or clone the training repository**: [Training Repo Link]
-- [ ] **Install Agent Mode plugin/extension** for your IDE
+- [ ] **Supported IDE installed** (VS Code recommended; Cursor supported; JetBrains supported but Agent Mode features may vary)
+- [ ] **Fork or clone the training repository**: https://github.com/moacir-rodrigues-petry/agentic-coding-wip
+- [ ] **Verify Agent Mode is available** in the Copilot Chat panel (Ask / Plan / Agent dropdown)
 - [ ] **Verify Agent Mode functionality** with a simple test prompt
 - [ ] **Join training Slack channel**: #copilot-agent-training
 
@@ -74,7 +74,7 @@ This intensive 1-hour workshop covers the essential aspects of GitHub Copilot Ag
 ### **1. Agent Mode Overview** 
 - What is Agent Mode and how it differs from traditional Copilot features
 - Key capabilities and use cases
-- When to use Agent Mode vs. inline/chat/edit modes
+- When to use each mode: Inline, Ask, Plan, and Agent
 
 ### **2. MCP (Model Context Protocol)**
 - Understanding Model Context Protocol architecture
@@ -165,13 +165,13 @@ Since this is a focused 1-hour overview, additional hands-on practice is availab
 ### **General Questions**
 
 **Q: What is MCP and how does it relate to Agent Mode?**
-A: Model Context Protocol (MCP) is the communication framework that enables Agent Mode to understand and interact with your development environment, providing project-aware context and enabling intelligent multi-file operations.
+A: Model Context Protocol (MCP) is an open protocol for connecting AI models to external tools and data sources — such as GitHub, Jira, Figma, or databases. Agent Mode's built-in codebase understanding (file reads, search, terminal access) is separate from MCP. MCP extends what the agent can reach *beyond* the local workspace.
 
 **Q: How quickly can teams start using Agent Mode after this training?**
 A: Teams can begin experimenting immediately with the setup guidance provided. Full integration typically takes 1-2 weeks depending on project complexity and security requirements.
 
-**Q: What's the difference between Agent Mode and Copilot Edits?**
-A: While Copilot Edits handles multi-file changes from single prompts, Agent Mode provides deeper architectural understanding, autonomous planning, and can handle complex workflows across entire projects.
+**Q: What's the difference between Ask, Plan, and Agent modes?**
+A: **Ask** is conversational — great for questions, explanations, and exploring options. **Plan** generates a structured, step-by-step implementation plan you can review and approve before any files are changed. **Agent** executes autonomously — it reads files, runs terminal commands, and implements changes across the entire project. Use Plan when you want to stay in control of scope; use Agent when the task is well-defined and you trust it to run.
 
 ### **Security and Governance**
 

--- a/WORKFLOW_SPEC_FIRST_APPROACH.md
+++ b/WORKFLOW_SPEC_FIRST_APPROACH.md
@@ -24,7 +24,7 @@ But here’s the key: you don’t write the spec manually. You generate it by pr
 
 **Open GitHub Copilot Chat in Agent Mode:** Make sure Agent Mode is active and has access to the codebase (using #codebase or context attachments). This gives the AI visibility into file structure, dependencies, and naming conventions, making its responses more grounded and accurate.
 
-**Use a Reasoning Model:** Pick a reasoning-capable model such as Claude Sonnet 4.x (with Thinking effort set to High), GPT o3/o4-mini, or Gemini 2.5 Pro. These models excel at multi-step thinking and structured dialogue, which is ideal for generating specs. Gemini 2.5 Pro has a particularly large context window (1M tokens), which can help when writing a plan over a very large codebase, though Claude 4.x models (200K+) are also well-suited for most projects.
+**Use a Reasoning Model:** Pick a reasoning-capable model such as Claude Sonnet 4.6 (with Thinking effort set to High), GPT-5.5, or Gemini 2.5 Pro. These models excel at multi-step thinking and structured dialogue, which is ideal for generating specs. Gemini 2.5 Pro has a particularly large context window (1M tokens), which can help when writing a plan over a very large codebase, though Claude Sonnet 4.6 (200K+) is also well-suited for most projects.
 
 **Create the files plan.md and todo.md:** Creating plan.md and todo.md ensures that AI coding agents work from a clear, structured understanding of the project. plan.md captures the full implementation blueprint, while todo.md breaks it into small, promptable tasks, enabling safer, more accurate code generation, better validation checkpoints, and faster, more reliable development cycles.
 

--- a/WORKFLOW_SPEC_FIRST_APPROACH.md
+++ b/WORKFLOW_SPEC_FIRST_APPROACH.md
@@ -24,7 +24,7 @@ But here’s the key: you don’t write the spec manually. You generate it by pr
 
 **Open GitHub Copilot Chat in Agent Mode:** Make sure Agent Mode is active and has access to the codebase (using #codebase or context attachments). This gives the AI visibility into file structure, dependencies, and naming conventions, making its responses more grounded and accurate.
 
-**Use a Reasoning Model:** Pick a model or enable reasoning in models like Claude Sonnet 3.7, GPT o\* or Gemini 2.5 Pro. These models excel at multi-step thinking and structured dialogue, which is ideal for generating specs. Gemini 2.5 Pro has a larger context window, which will help to write a better plan over a larger codebase.
+**Use a Reasoning Model:** Pick a reasoning-capable model such as Claude Sonnet 4.x (with Thinking effort set to High), GPT o3/o4-mini, or Gemini 2.5 Pro. These models excel at multi-step thinking and structured dialogue, which is ideal for generating specs. Gemini 2.5 Pro has a particularly large context window (1M tokens), which can help when writing a plan over a very large codebase, though Claude 4.x models (200K+) are also well-suited for most projects.
 
 **Create the files plan.md and todo.md:** Creating plan.md and todo.md ensures that AI coding agents work from a clear, structured understanding of the project. plan.md captures the full implementation blueprint, while todo.md breaks it into small, promptable tasks, enabling safer, more accurate code generation, better validation checkpoints, and faster, more reliable development cycles.
 


### PR DESCRIPTION
## Summary

Updates several handbook pages linked from workshop materials to reflect the current state of GitHub Copilot and available AI models as of May 2026.

## Changes

### Copilot modes and setup (TRAINING.md)
- Replaced the stale four-mode breakdown (Inline / Chat / Edits / Agent) with the current panel: **Inline, Ask, Plan, and Agent**
- Removed the phantom "Install Agent Mode plugin/extension" checklist step
- Corrected the training repository URL to `https://github.com/ModusCreateOrg/agentic-coding-training`
- Added a note that JetBrains support for Agent Mode features may vary
- Fixed the MCP FAQ, which incorrectly described MCP as the mechanism behind Agent Mode's built-in workspace understanding (MCP is for connecting AI to *external* tools/services)
- Replaced the outdated "Copilot Edits" FAQ entry with an accurate Ask / Plan / Agent breakdown

### Model references
- Updated all model names to current generation and aligned them with exact labels shown in the Copilot model picker
- **Claude:** `Claude 3.5 / 3.7` → `Claude Sonnet 4.6` (200K context, Thinking effort High)
- **OpenAI:** `GPT-4o` / `GPT o*` → `GPT-5.4 mini`, `GPT-5.4`, `GPT-5.5` with per-model guidance
- **Google:** `Gemini 2.5 Pro` section updated to include `Gemini 3.1 Pro (Preview)` and `Gemini 3 Flash (Preview)` as the lighter alternative
- Comparison table and best-practices bullet updated to match

## References
- [VS Code Copilot agents overview — Choose an agent](https://code.visualstudio.com/docs/copilot/agents/overview#_choose-an-agent): Confirms the three built-in agents (Ask, Plan, Agent) and the always-on Inline mode
- [Model Context Protocol (MCP)](https://modelcontextprotocol.io/introduction): Confirms MCP is a protocol for connecting AI to external tools and services, not the mechanism behind built-in workspace understanding
- [Training repository](https://github.com/ModusCreateOrg/agentic-coding-training): Correct repo URL as listed on the workshop wiki

## Testing
- All links verified
- Model names confirmed against the Copilot model picker (May 5, 2026 snapshot)